### PR TITLE
Replace defunct YouTube link with official website

### DIFF
--- a/guide/04-structure-and-preparation.md
+++ b/guide/04-structure-and-preparation.md
@@ -162,7 +162,7 @@ brief introduction in the debrief to remind participants what you are all there
 for: a semi-structured group interview. Nothing more.
 
 [3]: Sidney Dekker has produced a set of short seminars that we recommend as an
-introduction to this topic: https:// www.youtube.com/watch?v=PVWjgqDANWA
+introduction to this topic: https://sidneydekker.com/films/
 
 > **Your introduction is meant to set up the paradigm within which everyone will
 > operate for the duration of the debrief. Here is some sample introduction


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

The YouTube link is defunct and that user (now at https://www.youtube.com/@sidneydekkercom) has removed the Just Culture videos from YouTube entirely.

They are now on Vimeo and accessible from his website at https://sidneydekker.com/films/.

## Context / Why are we making this change?

Dead link.

## Testing and QA Plan

Manually click the new link.

## Impact

Allows interested people to see the recommended videos again.